### PR TITLE
Test scan relay timestamp filtering boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
             go2_yolo_detector/go2_yolo_detector/ \
             go2_yolo_navigator/go2_yolo_navigator/ \
             go2_yolo_bringup/scripts/ \
+            go2_yolo_bringup/test/ \
             evaluation/ \
             --select E,F,W,I --ignore E501,E402
+
+      - name: Test scan timestamp filtering
+        run: python -m unittest discover -s go2_yolo_bringup/test -v
 
   build:
     name: Build (ROS 2 Humble)

--- a/go2_yolo_bringup/CMakeLists.txt
+++ b/go2_yolo_bringup/CMakeLists.txt
@@ -11,4 +11,8 @@ install(PROGRAMS scripts/scan_relay.py scripts/demo_scenario.py
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(FILES scripts/scan_filter.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 ament_package()

--- a/go2_yolo_bringup/scripts/scan_filter.py
+++ b/go2_yolo_bringup/scripts/scan_filter.py
@@ -1,0 +1,16 @@
+"""Pure timestamp helpers for the laser scan relay."""
+
+NANOSECONDS_PER_SECOND = 1_000_000_000
+
+
+def scan_age_seconds(now_ns, scan_sec, scan_nanosec):
+    """Return the scan age relative to the current clock in seconds."""
+    scan_ns = scan_sec * NANOSECONDS_PER_SECOND + scan_nanosec
+    return (now_ns - scan_ns) / NANOSECONDS_PER_SECOND
+
+
+def should_forward_scan(now_ns, scan_sec, scan_nanosec, max_age_s):
+    """Return whether the clock has started and the scan is not stale."""
+    if now_ns == 0:
+        return False
+    return scan_age_seconds(now_ns, scan_sec, scan_nanosec) <= max_age_s

--- a/go2_yolo_bringup/scripts/scan_relay.py
+++ b/go2_yolo_bringup/scripts/scan_relay.py
@@ -17,6 +17,8 @@ from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import LaserScan
 
+from scan_filter import scan_age_seconds, should_forward_scan
+
 MAX_AGE_S = 1.0   # discard scans older than this many sim-seconds
 
 
@@ -42,10 +44,18 @@ class ScanRelay(Node):
         if now_ns == 0:
             return  # sim clock not yet received
 
-        scan_ns = msg.header.stamp.sec * 10**9 + msg.header.stamp.nanosec
-        age_s = (now_ns - scan_ns) / 1e9
+        age_s = scan_age_seconds(
+            now_ns,
+            msg.header.stamp.sec,
+            msg.header.stamp.nanosec,
+        )
 
-        if age_s > MAX_AGE_S:
+        if not should_forward_scan(
+            now_ns,
+            msg.header.stamp.sec,
+            msg.header.stamp.nanosec,
+            MAX_AGE_S,
+        ):
             self._dropped += 1
             if self._dropped % 20 == 1:
                 self.get_logger().warn(

--- a/go2_yolo_bringup/test/test_scan_filter.py
+++ b/go2_yolo_bringup/test/test_scan_filter.py
@@ -1,0 +1,41 @@
+"""Tests for the scan relay timestamp filter."""
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from scan_filter import scan_age_seconds, should_forward_scan  # noqa: E402
+
+
+class ScanFilterTest(unittest.TestCase):
+    """Exercise fresh, boundary, stale, and uninitialized clock cases."""
+
+    def test_age_uses_seconds_and_nanoseconds(self):
+        """The helper must preserve sub-second timestamp precision."""
+        now_ns = 12_500_000_000
+        self.assertEqual(scan_age_seconds(now_ns, 12, 250_000_000), 0.25)
+
+    def test_fresh_scan_is_forwarded(self):
+        """A scan inside the maximum age remains eligible for relay."""
+        self.assertTrue(should_forward_scan(10_000_000_000, 9, 250_000_000, 1.0))
+
+    def test_boundary_scan_is_forwarded(self):
+        """A scan exactly at the configured age limit is still valid."""
+        self.assertTrue(should_forward_scan(10_000_000_000, 9, 0, 1.0))
+
+    def test_stale_scan_is_dropped(self):
+        """A scan one nanosecond beyond the age limit is rejected."""
+        self.assertFalse(
+            should_forward_scan(10_000_000_000, 8, 999_999_999, 1.0)
+        )
+
+    def test_scan_is_dropped_before_sim_clock_starts(self):
+        """No scan is relayed while simulated time is still zero."""
+        self.assertFalse(should_forward_scan(0, 0, 0, 1.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

While tracing the `/scan` to `/scan_slam` handoff, I noticed the stale-message decision was embedded in the ROS callback, which made the one-second boundary difficult to exercise without a running ROS graph.

- move the timestamp arithmetic and forwarding predicate into a small ROS-independent helper
- cover fresh, exact-boundary, stale, sub-second, and uninitialized simulated-clock cases
- run the regression test in the existing CI job and install the helper beside `scan_relay.py`

The relay keeps its existing topic, QoS, logging, and timestamp behavior.

## Validation

- `python -m unittest discover -s go2_yolo_bringup/test -v` (5 passed)
- `python -m compileall -q go2_yolo_bringup/scripts go2_yolo_bringup/test`
- `git diff --check`